### PR TITLE
Add dependency on Click.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=['magicov',],
     license='GPLv3+',
     # long_description=open('README.txt').read(),
-    install_requires=['google-pasta', 'coverage'],
+    install_requires=['google-pasta', 'coverage', 'click'],
     entry_points={
         'console_scripts': [
             'magicov=magicov:main'


### PR DESCRIPTION
Without this, I got an error trying to run magicov:

```
$ magicov
Traceback (most recent call last):
  File "/Users/jorendorff/work/rust-frontend/js/jsparagus/jsparagus_build_venv/bin/magicov", line 5, in <module>
    from magicov import main
  File "/Users/jorendorff/work/rust-frontend/js/jsparagus/jsparagus_build_venv/lib/python3.7/site-packages/magicov/__init__.py", line 19, in <module>
    import click
ModuleNotFoundError: No module named 'click'
```